### PR TITLE
Fix autostart compatibility with older webOS

### DIFF
--- a/autostart.sh
+++ b/autostart.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-timeout 5 luna-send -n 1 'luna://org.webosbrew.vncserver.service/start' '{"autostart": true}'
+timeout -t 5 luna-send -n 1 'luna://org.webosbrew.vncserver.service/start' '{"autostart": true}' || \
+  test "$?" -eq 143 || timeout 5 luna-send -n 1 'luna://org.webosbrew.vncserver.service/start' '{"autostart": true}'


### PR DESCRIPTION
Commit 39c15e2 broke the startup script on webOS <7. Busybox `timeout` stopped accepting `-t` some time between v1.29.3 (webOS 6) and v1.31.1 (webOS 7), but the older versions require it.

This script tries to run `timeout` with `-t` first, and if that fails for a reason other than timing out it tries without `-t`. An exit status of 143 indicates the process received SIGTERM (i.e., timed out).