### PR TITLE
Fix autostart compatibility

### DIFF
--- a/autostart.sh
+++ b/autostart.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-timeout 5 luna-send -n 1 'luna://org.webosbrew.vncserver.service/start' '{"autostart": true}'
+command='luna-send -n 1 luna://org.webosbrew.vncserver.service/start {"autostart":true}'
+timeout -t 5 $command || [ $? -eq 143 ] || timeout 5 $command


### PR DESCRIPTION
Commit 39c15e2 broke the startup script on webOS <7.

Busybox `timeout` requires different arguments on old and new webOS. Until webOS 6 (Busybox 1.29.3), the timeout duration must be specified with `-t`. As of webOS 7 (Busybox 1.31.1), `-t` is no longer accepted.

I tried using `luna-send -w` (which is *present* on webOS 1, 4.0, and 6), but it's broken on at least webOS 1. It waits the full timeout length (here, 5 seconds), even after a response is received. When you use `-w` with `-n 1` on later versions, receiving a response causes it to exit immediately.

So I've changed this PR to a shorter version of my previous method.