### PR TITLE
Fix Luna examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ luna-send -n 1 'luna://org.webosbrew.vncserver.service/start' '{}'
 
 # Building
 ## Service
-To cross-compile for WebOS, you will [need an
-toolchain](https://github.com/openlgtv/buildroot-nc4/releases/tag/webos-c592d84).
+To cross-compile for WebOS, you will [need a
+toolchain](https://github.com/openlgtv/buildroot-nc4/releases/tag/webos-b17b4cc).
 
 ```sh
 cmake -S . -B build && cmake --build build --target webos-vncserver --target capture_gm --target capture_halgal

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Service can be controlled using Luna service bus calls:
 
 As usual - all these commands can be issued using `luna-send` command like so:
 ```sh
-luna-send -n 1 'luna://org.webosbrew.hbchannel.service/configure' '{"password": "test"}'
-luna-send -n 1 'luna://org.webosbrew.hbchannel.service/start' '{}'
+luna-send -n 1 'luna://org.webosbrew.vncserver.service/configure' '{"password": "test"}'
+luna-send -n 1 'luna://org.webosbrew.vncserver.service/start' '{}'
 ```
 
 # Building


### PR DESCRIPTION
The `luna-send` examples referred to `org.webosbrew.hbchannel.service` rather than `org.webosbrew.vncserver.service`. (Discovered by @Presjar on Discord.)

Also updated the toolchain link.